### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> # Deprecated
+> Use the upstream [Mottie/javascript-number-formatter](https://github.com/Mottie/javascript-number-formatter) instead. Use:
+>
+>     npm install number-format.js
+
 # Javascript Number Formatter
 
 Lightweight & Fast JavaScript Number Formatter


### PR DESCRIPTION
It seems the upstream version https://github.com/Mottie/javascript-number-formatter is more updated.
